### PR TITLE
Fix logic in MySqlQueryableMethodTranslatingExpressionVisitor.IsVaidSelectExpressionForExecuteDelete 

### DIFF
--- a/src/EFCore.MySql/Query/Internal/MySqlQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlQueryableMethodTranslatingExpressionVisitor.cs
@@ -86,12 +86,11 @@ public class MySqlQueryableMethodTranslatingExpressionVisitor : RelationalQuerya
     protected override bool IsValidSelectExpressionForExecuteDelete(SelectExpression selectExpression)
         => selectExpression is
            {
-               Orderings: [],
                Offset: null,
-               Limit: null,
                GroupBy: [],
                Having: null
            } &&
+           (selectExpression.Tables.Count == 1 || (selectExpression.Orderings.Count == 0 && selectExpression.Limit is null)) &&
            selectExpression.Tables[0] is TableExpression &&
            selectExpression.Tables.Skip(1).All(t => t is InnerJoinExpression);
 

--- a/test/EFCore.MySql.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesMySqlTest.cs
@@ -78,19 +78,14 @@ WHERE FALSE
     {
         if (!AppConfig.ServerVersion.Supports.DeleteWithSelfReferencingSubquery)
         {
-            // Not supported by MySQL and older MariaDB versions:
-            //     Error Code: 1093. You can't specify target table 'o' for update in FROM clause
-            await Assert.ThrowsAsync<MySqlException>(
-                () => base.Delete_Where_OrderBy(async));
+            await base.Delete_Where_OrderBy(async);
 
             AssertSql(
 """
-DELETE `o`
-FROM `Order Details` AS `o`
-WHERE EXISTS (
-    SELECT 1
-    FROM `Order Details` AS `o0`
-    WHERE (`o0`.`OrderID` < 10300) AND ((`o0`.`OrderID` = `o`.`OrderID`) AND (`o0`.`ProductID` = `o`.`ProductID`)))
+DELETE
+FROM `Order Details`
+WHERE `OrderID` < 10300
+ORDER BY `OrderID`
 """);
         }
         else
@@ -137,27 +132,17 @@ WHERE EXISTS (
 
     public override async Task Delete_Where_OrderBy_Take(bool async)
     {
-        // This query uses a derived table pattern which works on both MySQL and MariaDB.
-        // The derived table (AS `o1`) materializes the result, avoiding the MySQL error 1093
-        // "You can't specify target table for update in FROM clause"
         await base.Delete_Where_OrderBy_Take(async);
 
         AssertSql(
 """
 @p='100'
 
-DELETE `o`
-FROM `Order Details` AS `o`
-WHERE EXISTS (
-    SELECT 1
-    FROM (
-        SELECT `o0`.`OrderID`, `o0`.`ProductID`
-        FROM `Order Details` AS `o0`
-        WHERE `o0`.`OrderID` < 10300
-        ORDER BY `o0`.`OrderID`
-        LIMIT @p
-    ) AS `o1`
-    WHERE (`o1`.`OrderID` = `o`.`OrderID`) AND (`o1`.`ProductID` = `o`.`ProductID`))
+DELETE
+FROM `Order Details`
+WHERE `OrderID` < 10300
+ORDER BY `OrderID`
+LIMIT @p
 """);
     }
 
@@ -214,26 +199,16 @@ WHERE EXISTS (
 
     public override async Task Delete_Where_Take(bool async)
     {
-        // This query uses a derived table pattern which works on both MySQL and MariaDB.
-        // The derived table (AS `o1`) materializes the result, avoiding the MySQL error 1093
-        // "You can't specify target table for update in FROM clause"
         await base.Delete_Where_Take(async);
 
         AssertSql(
 """
 @p='100'
 
-DELETE `o`
-FROM `Order Details` AS `o`
-WHERE EXISTS (
-    SELECT 1
-    FROM (
-        SELECT `o0`.`OrderID`, `o0`.`ProductID`
-        FROM `Order Details` AS `o0`
-        WHERE `o0`.`OrderID` < 10300
-        LIMIT @p
-    ) AS `o1`
-    WHERE (`o1`.`OrderID` = `o`.`OrderID`) AND (`o1`.`ProductID` = `o`.`ProductID`))
+DELETE
+FROM `Order Details`
+WHERE `OrderID` < 10300
+LIMIT @p
 """);
     }
 

--- a/test/EFCore.MySql.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesMySqlTest.cs
@@ -76,32 +76,15 @@ WHERE FALSE
 
     public override async Task Delete_Where_OrderBy(bool async)
     {
-        if (!AppConfig.ServerVersion.Supports.DeleteWithSelfReferencingSubquery)
-        {
-            await base.Delete_Where_OrderBy(async);
+        await base.Delete_Where_OrderBy(async);
 
-            AssertSql(
+        AssertSql(
 """
 DELETE
 FROM `Order Details`
 WHERE `OrderID` < 10300
 ORDER BY `OrderID`
 """);
-        }
-        else
-        {
-            await base.Delete_Where_OrderBy(async);
-
-            AssertSql(
-"""
-DELETE `o`
-FROM `Order Details` AS `o`
-WHERE EXISTS (
-    SELECT 1
-    FROM `Order Details` AS `o0`
-    WHERE (`o0`.`OrderID` < 10300) AND ((`o0`.`OrderID` = `o`.`OrderID`) AND (`o0`.`ProductID` = `o`.`ProductID`)))
-""");
-        }
     }
 
     public override async Task Delete_Where_OrderBy_Skip(bool async)


### PR DESCRIPTION
- Fix logic in MySqlQueryableMethodTranslatingExpressionVisitor.IsVaidSelectExpressionForExecuteDelete to allow for single table delete w/ ORDER BY or LIMIT to process correctly.

- Fix Northwind unit tests related to the above.

EF Core 10 (maybe 9) will generate a DELETE using an IN subselect with a LIMIT clause when using Take() with ExecuteDelete() when IsVaidSelectExpressionForExecuteDelete returns false. This causes a MySQL error "This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'". The original Pomelo version of IsVaidSelectExpressionForExecuteDelete doesn't check for ORDER BY or LIMIT and would return true and therefore generate a correct statement.

Compounding this issue is the default Northwind unit tests do work (albeit w/ inffecient queries). Because the table used in the test has a compound primary key, the IN is re-written as an EXISTS which MySQL can handle. There's probably other delete scenarios that are not being handled correctly in this and the original Pomelo version, but this change at least gets the basic stuff working again.