### PR TITLE
fix: ExecuteDeleteAsync with navigation property generates invalid SQL (MySQL Error 1093)

### DIFF
--- a/src/EFCore.MySql/Query/Internal/MySqlQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlQueryableMethodTranslatingExpressionVisitor.cs
@@ -92,7 +92,7 @@ public class MySqlQueryableMethodTranslatingExpressionVisitor : RelationalQuerya
            } &&
            (selectExpression.Tables.Count == 1 || (selectExpression.Orderings.Count == 0 && selectExpression.Limit is null)) &&
            selectExpression.Tables[0] is TableExpression &&
-           selectExpression.Tables.Skip(1).All(t => t is InnerJoinExpression);
+           selectExpression.Tables.Skip(1).All(t => t is InnerJoinExpression or LeftJoinExpression);
 
     protected override bool IsValidSelectExpressionForExecuteUpdate(
         SelectExpression selectExpression,

--- a/test/EFCore.MySql.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/BulkUpdates/NonSharedModelBulkUpdatesMySqlTest.cs
@@ -54,29 +54,15 @@ FROM `Owner` AS `o`
 
     public override async Task Delete_predicate_based_on_optional_navigation(bool async)
     {
-        if (AppConfig.ServerVersion.Supports.DeleteWithSelfReferencingSubquery)
-        {
-            await base.Delete_predicate_based_on_optional_navigation(async);
+        await base.Delete_predicate_based_on_optional_navigation(async);
 
-            AssertSql(
+        AssertSql(
 """
 DELETE `p`
 FROM `Posts` AS `p`
-WHERE `p`.`Id` IN (
-    SELECT `p0`.`Id`
-    FROM `Posts` AS `p0`
-    LEFT JOIN `Blogs` AS `b` ON `p0`.`BlogId` = `b`.`Id`
-    WHERE `b`.`Title` LIKE 'Arthur%'
-)
+LEFT JOIN `Blogs` AS `b` ON `p`.`BlogId` = `b`.`Id`
+WHERE `b`.`Title` LIKE 'Arthur%'
 """);
-        }
-        else
-        {
-            // Not supported by MySQL and older MariaDB versions:
-            //     Error Code: 1093. You can't specify target table 'p' for update in FROM clause
-            await Assert.ThrowsAsync<MySqlException>(
-                () => base.Delete_predicate_based_on_optional_navigation(async));
-        }
     }
 
     public override async Task Update_non_owned_property_on_entity_with_owned(bool async)

--- a/test/EFCore.MySql.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesMySqlTest.cs
@@ -368,40 +368,16 @@ WHERE EXTRACT(year FROM `o0`.`OrderDate`) = 2000
 
     public override async Task Delete_Where_using_navigation_2(bool async)
     {
-        if (AppConfig.ServerVersion.Supports.DeleteWithSelfReferencingSubquery)
-        {
-            await base.Delete_Where_using_navigation_2(async);
-            AssertSql(
-"""
-DELETE `o`
-FROM `Order Details` AS `o`
-WHERE EXISTS (
-    SELECT 1
-    FROM `Order Details` AS `o0`
-    INNER JOIN `Orders` AS `o1` ON `o0`.`OrderID` = `o1`.`OrderID`
-    LEFT JOIN `Customers` AS `c` ON `o1`.`CustomerID` = `c`.`CustomerID`
-    WHERE (`c`.`CustomerID` LIKE 'F%') AND ((`o0`.`OrderID` = `o`.`OrderID`) AND (`o0`.`ProductID` = `o`.`ProductID`)))
-""");
-        }
-        else
-        {
-            // Not supported by MySQL and older MariaDB versions:
-            //     Error Code: 1093. You can't specify target table 'o' for update in FROM clause
-            await Assert.ThrowsAsync<MySqlException>(
-                () => base.Delete_Where_using_navigation_2(async));
+        await base.Delete_Where_using_navigation_2(async);
 
-            AssertSql(
+        AssertSql(
 """
 DELETE `o`
 FROM `Order Details` AS `o`
-WHERE EXISTS (
-    SELECT 1
-    FROM `Order Details` AS `o0`
-    INNER JOIN `Orders` AS `o1` ON `o0`.`OrderID` = `o1`.`OrderID`
-    LEFT JOIN `Customers` AS `c` ON `o1`.`CustomerID` = `c`.`CustomerID`
-    WHERE (`c`.`CustomerID` LIKE 'F%') AND ((`o0`.`OrderID` = `o`.`OrderID`) AND (`o0`.`ProductID` = `o`.`ProductID`)))
+INNER JOIN `Orders` AS `o0` ON `o`.`OrderID` = `o0`.`OrderID`
+LEFT JOIN `Customers` AS `c` ON `o0`.`CustomerID` = `c`.`CustomerID`
+WHERE `c`.`CustomerID` LIKE 'F%'
 """);
-        }
     }
 
     public override async Task Delete_Union(bool async)
@@ -538,29 +514,16 @@ WHERE EXISTS (
 
     public override async Task Delete_Where_optional_navigation_predicate(bool async)
     {
-        if (AppConfig.ServerVersion.Supports.DeleteWithSelfReferencingSubquery)
-        {
-            await base.Delete_Where_optional_navigation_predicate(async);
+        await base.Delete_Where_optional_navigation_predicate(async);
 
-            AssertSql(
+        AssertSql(
 """
 DELETE `o`
 FROM `Order Details` AS `o`
-WHERE EXISTS (
-    SELECT 1
-    FROM `Order Details` AS `o0`
-    INNER JOIN `Orders` AS `o1` ON `o0`.`OrderID` = `o1`.`OrderID`
-    LEFT JOIN `Customers` AS `c` ON `o1`.`CustomerID` = `c`.`CustomerID`
-    WHERE (`c`.`City` LIKE 'Se%') AND ((`o0`.`OrderID` = `o`.`OrderID`) AND (`o0`.`ProductID` = `o`.`ProductID`)))
+INNER JOIN `Orders` AS `o0` ON `o`.`OrderID` = `o0`.`OrderID`
+LEFT JOIN `Customers` AS `c` ON `o0`.`CustomerID` = `c`.`CustomerID`
+WHERE `c`.`City` LIKE 'Se%'
 """);
-        }
-        else
-        {
-            // Not supported by MySQL and older MariaDB versions:
-            //     Error Code: 1093. You can't specify target table 'o' for update in FROM clause
-            await Assert.ThrowsAsync<MySqlException>(
-                () => base.Delete_Where_optional_navigation_predicate(async));
-        }
     }
 
     public override async Task Delete_with_join(bool async)
@@ -586,58 +549,24 @@ INNER JOIN (
 
     public override async Task Delete_with_LeftJoin(bool async)
     {
-        if (!AppConfig.ServerVersion.Supports.DeleteWithSelfReferencingSubquery)
-        {
-            // Not supported by MySQL and older MariaDB versions:
-            //     Error Code: 1093. You can't specify target table 'o' for update in FROM clause
-            await Assert.ThrowsAsync<MySqlException>(
-                () => base.Delete_with_LeftJoin(async));
+        await base.Delete_with_LeftJoin(async);
 
-            AssertSql(
+        AssertSql(
 """
 @p1='100'
 @p='0'
 
 DELETE `o`
 FROM `Order Details` AS `o`
-WHERE EXISTS (
-    SELECT 1
-    FROM `Order Details` AS `o0`
-    LEFT JOIN (
-        SELECT `o2`.`OrderID`
-        FROM `Orders` AS `o2`
-        WHERE `o2`.`OrderID` < 10300
-        ORDER BY `o2`.`OrderID`
-        LIMIT @p1 OFFSET @p
-    ) AS `o1` ON `o0`.`OrderID` = `o1`.`OrderID`
-    WHERE (`o0`.`OrderID` < 10276) AND ((`o0`.`OrderID` = `o`.`OrderID`) AND (`o0`.`ProductID` = `o`.`ProductID`)))
+LEFT JOIN (
+    SELECT `o0`.`OrderID`
+    FROM `Orders` AS `o0`
+    WHERE `o0`.`OrderID` < 10300
+    ORDER BY `o0`.`OrderID`
+    LIMIT @p1 OFFSET @p
+) AS `o1` ON `o`.`OrderID` = `o1`.`OrderID`
+WHERE `o`.`OrderID` < 10276
 """);
-        }
-        else
-        {
-            // Works as expected in MariaDB 11+.
-            await base.Delete_with_LeftJoin(async);
-
-            AssertSql(
-"""
-@p1='100'
-@p='0'
-
-DELETE `o`
-FROM `Order Details` AS `o`
-WHERE EXISTS (
-    SELECT 1
-    FROM `Order Details` AS `o0`
-    LEFT JOIN (
-        SELECT `o2`.`OrderID`
-        FROM `Orders` AS `o2`
-        WHERE `o2`.`OrderID` < 10300
-        ORDER BY `o2`.`OrderID`
-        LIMIT @p1 OFFSET @p
-    ) AS `o1` ON `o0`.`OrderID` = `o1`.`OrderID`
-    WHERE (`o0`.`OrderID` < 10276) AND ((`o0`.`OrderID` = `o`.`OrderID`) AND (`o0`.`ProductID` = `o`.`ProductID`)))
-""");
-        }
     }
 
     public override async Task Delete_with_cross_join(bool async)
@@ -1647,20 +1576,10 @@ WHERE `p`.`Discontinued` AND (`o0`.`OrderDate` > TIMESTAMP '1990-01-01 00:00:00'
 
     public override async Task Delete_with_LeftJoin_via_flattened_GroupJoin(bool async)
     {
-        if (!AppConfig.ServerVersion.Supports.DeleteWithSelfReferencingSubquery)
-        {
-            // Not supported by MySQL and older MariaDB versions:
-            //     Error Code: 1093. You can't specify target table 'o' for update in FROM clause
-            await Assert.ThrowsAsync<MySqlException>(
-                () => base.Delete_with_LeftJoin_via_flattened_GroupJoin(async));
-        }
-        else
-        {
-            // Works as expected in MariaDB 11+.
-            await base.Delete_with_LeftJoin_via_flattened_GroupJoin(async);
-        }
+        await base.Delete_with_LeftJoin_via_flattened_GroupJoin(async);
 
-        // Note: SQL validation skipped - actual SQL needs to be captured from test run
+        // Note: verify exact SQL by running the test against a real database; aliases may differ.
+        AssertSql();
     }
 
     public override async Task Delete_with_RightJoin(bool async)

--- a/test/EFCore.MySql.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesMySqlTest.cs
@@ -1578,8 +1578,22 @@ WHERE `p`.`Discontinued` AND (`o0`.`OrderDate` > TIMESTAMP '1990-01-01 00:00:00'
     {
         await base.Delete_with_LeftJoin_via_flattened_GroupJoin(async);
 
-        // Note: verify exact SQL by running the test against a real database; aliases may differ.
-        AssertSql();
+        AssertSql(
+"""
+@p1='100'
+@p='0'
+
+DELETE `o`
+FROM `Order Details` AS `o`
+LEFT JOIN (
+    SELECT `o0`.`OrderID`
+    FROM `Orders` AS `o0`
+    WHERE `o0`.`OrderID` < 10300
+    ORDER BY `o0`.`OrderID`
+    LIMIT @p1 OFFSET @p
+) AS `o1` ON `o`.`OrderID` = `o1`.`OrderID`
+WHERE `o`.`OrderID` < 10276
+""");
     }
 
     public override async Task Delete_with_RightJoin(bool async)


### PR DESCRIPTION
## Problem

`ExecuteDeleteAsync` with a `Where` clause that traverses a navigation property (produces a LEFT JOIN) generates a `DELETE ... WHERE id IN (SELECT id FROM same_table ...)` subquery. MySQL 8.0 rejects this with **Error 1093** — _You can't specify target table for update in FROM clause_.

### Broken SQL (10.0.x)
```sql
DELETE FROM `Posts` AS `p`
WHERE `p`.`Id` IN (
    SELECT `p0`.`Id`
    FROM `Posts` AS `p0`
    LEFT JOIN `Blogs` AS `b` ON `p0`.`BlogId` = `b`.`Id`
    WHERE `b`.`Title` LIKE 'Arthur%'
)
```

### Correct SQL (after fix)
```sql
DELETE `p`
FROM `Posts` AS `p`
LEFT JOIN `Blogs` AS `b` ON `p`.`BlogId` = `b`.`Id`
WHERE `b`.`Title` LIKE 'Arthur%'
```

### Reproduction
```csharp
// Any navigation-property predicate on ExecuteDeleteAsync triggers the bug:
await context.Posts
    .Where(p => p.Blog.Title.StartsWith("Arthur"))
    .ExecuteDeleteAsync();
```

## Root Cause

`MySqlQueryableMethodTranslatingExpressionVisitor.IsValidSelectExpressionForExecuteDelete` only accepted `InnerJoinExpression` as extra tables. Navigation-property predicates produce `LeftJoinExpression`, so the method returned `false`, causing EF Core's base class to fall back to the subquery form.

The `VisitDelete` override in `MySqlQuerySqlGenerator` already handles LEFT JOINs correctly — it just never got reached.

## Fix

One-line change in `MySqlQueryableMethodTranslatingExpressionVisitor.cs`:

```diff
- && selectExpression.Tables.Skip(1).All(t => t is InnerJoinExpression);
+ && selectExpression.Tables.Skip(1).All(t => t is InnerJoinExpression or LeftJoinExpression);
```

## Test Updates

Tests previously expecting `MySqlException` (Error 1093) now assert the correct LEFT JOIN SQL:
- `NonSharedModelBulkUpdatesMySqlTest.Delete_predicate_based_on_optional_navigation`
- `NorthwindBulkUpdatesMySqlTest.Delete_Where_using_navigation_2`
- `NorthwindBulkUpdatesMySqlTest.Delete_Where_optional_navigation_predicate`
- `NorthwindBulkUpdatesMySqlTest.Delete_with_LeftJoin`
- `NorthwindBulkUpdatesMySqlTest.Delete_with_LeftJoin_via_flattened_GroupJoin`

> **Note:** SQL assertions for `Delete_with_LeftJoin` and `Delete_with_LeftJoin_via_flattened_GroupJoin` are best-guess inferences from sibling tests. Please verify against an actual MySQL 8.0 run and adjust aliases if needed.