### PR TITLE
Fix #353: read back DB-generated key columns on MariaDB via RETURNING

### DIFF
--- a/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
+++ b/src/EFCore.MySql/Infrastructure/MariaDbServerVersion.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore
                                                                            ServerVersion.Version.Major == 10 && ServerVersion.Version.Minor == 2 && ServerVersion.Version.Build >= 22; // MySQL is missing the explicit TABLE_NAME column that MariaDB supports, so always join the TABLE_CONSTRAINTS table when accessing CHECK_CONSTRAINTS for any database server that supports CHECK_CONSTRAINTS.
             public override bool IdentifyJsonColumsByCheckConstraints => true;
             public override bool MySqlBugLimit0Offset0ExistsWorkaround => ServerVersion.Version < new Version(11, 6, 2); // MariaDB versions before 11.6.2 have a bug with LIMIT 0 OFFSET 0 in EXISTS subqueries
-            public override bool Returning => false; // MariaDB does not support the RETURNING clause
+            public override bool Returning => ServerVersion.Version >= new Version(10, 5, 0); // MariaDB supports INSERT/DELETE RETURNING since 10.5 (UPDATE RETURNING is not supported)
             public override bool CommonTableExpressions => ServerVersion.Version >= new Version(10, 2, 1);
             public override bool LimitWithinInAllAnySomeSubquery => false;
             public override bool LimitWithNonConstantValue => false;

--- a/src/EFCore.MySql/Update/Internal/MySqlUpdateSqlGenerator.cs
+++ b/src/EFCore.MySql/Update/Internal/MySqlUpdateSqlGenerator.cs
@@ -66,8 +66,10 @@ namespace Microting.EntityFrameworkCore.MySql.Update.Internal
             AppendValuesHeader(commandStringBuilder, writeOperations);
             AppendValues(commandStringBuilder, name, schema, writeOperations);
 
-            // RETURNING is not supported by MySQL. MariaDB supports INSERT/DELETE RETURNING but not UPDATE RETURNING,
-            // so we disable it for both databases to ensure consistent behavior across all DML operations.
+            // MySQL does not support RETURNING (Supports.Returning is false), so this falls back to the
+            // base INSERT + SELECT path. MariaDB 10.5+ supports INSERT RETURNING, which is required to read
+            // back database-generated key columns (e.g. a generated timestamp in a composite key) that
+            // LAST_INSERT_ID() cannot retrieve.
             if (_options.ServerVersion.Supports.Returning && readOperations.Count > 0)
             {
                 AppendReturningClause(commandStringBuilder, readOperations);
@@ -179,62 +181,10 @@ namespace Microting.EntityFrameworkCore.MySql.Update.Internal
             }
         }
 
-        public override ResultSetMapping AppendUpdateOperation(
-            StringBuilder commandStringBuilder,
-            IReadOnlyModificationCommand command,
-            int commandPosition,
-            out bool requiresTransaction)
-        {
-            var result = _options.ServerVersion.Supports.Returning
-                ? AppendUpdateReturningOperation(commandStringBuilder, command, commandPosition, out requiresTransaction)
-                : base.AppendUpdateOperation(commandStringBuilder, command, commandPosition, out requiresTransaction);
-
-            return result;
-        }
-
-        /// <summary>
-        /// Appends SQL for updating a row to the commands being built, via an UPDATE containing a RETURNING clause
-        /// to retrieve any database-generated values or for concurrency checking.
-        /// </summary>
-        /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
-        /// <param name="command">The command that represents the update operation.</param>
-        /// <param name="commandPosition">The ordinal of this command in the batch.</param>
-        /// <param name="requiresTransaction">Returns whether the SQL appended must be executed in a transaction to work correctly.</param>
-        /// <returns>The <see cref="ResultSetMapping" /> for the command.</returns>
-        protected override ResultSetMapping AppendUpdateReturningOperation(
-            StringBuilder commandStringBuilder,
-            IReadOnlyModificationCommand command,
-            int commandPosition,
-            out bool requiresTransaction)
-        {
-            var name = command.TableName;
-            var schema = command.Schema;
-            var operations = command.ColumnModifications;
-
-            var writeOperations = operations.Where(o => o.IsWrite).ToList();
-            var conditionOperations = operations.Where(o => o.IsCondition).ToList();
-            var readOperations = operations.Where(o => o.IsRead).ToList();
-
-            requiresTransaction = false;
-
-            var anyReadOperations = readOperations.Count > 0;
-
-            AppendUpdateCommandHeader(commandStringBuilder, name, schema, writeOperations);
-            AppendWhereClause(commandStringBuilder, conditionOperations);
-
-            // RETURNING is not supported by MySQL. MariaDB supports INSERT/DELETE RETURNING but not UPDATE RETURNING,
-            // so we disable it for both databases to ensure consistent behavior across all DML operations.
-            if (_options.ServerVersion.Supports.Returning)
-            {
-                AppendReturningClause(commandStringBuilder, readOperations, anyReadOperations ? null : "1");
-            }
-
-            commandStringBuilder.AppendLine(SqlGenerationHelper.StatementTerminator);
-
-            return anyReadOperations
-                ? ResultSetMapping.LastInResultSet
-                : ResultSetMapping.LastInResultSet | ResultSetMapping.ResultSetWithRowsAffectedOnly;
-        }
+        // UPDATE intentionally has no RETURNING override: MySQL has no RETURNING clause at all, and MariaDB
+        // supports RETURNING only for INSERT and DELETE (not UPDATE). UPDATE therefore always uses the base
+        // UpdateAndSelectSqlGenerator behavior (UPDATE followed by a SELECT ... WHERE ROW_COUNT() = 1 ...),
+        // which works on every supported server version.
 
         public override ResultSetMapping AppendDeleteOperation(StringBuilder commandStringBuilder,
             IReadOnlyModificationCommand command,
@@ -268,8 +218,9 @@ namespace Microting.EntityFrameworkCore.MySql.Update.Internal
             AppendDeleteCommandHeader(commandStringBuilder, name, schema);
             AppendWhereClause(commandStringBuilder, conditionOperations);
 
-            // RETURNING is not supported by MySQL. MariaDB supports INSERT/DELETE RETURNING but not UPDATE RETURNING,
-            // so we disable it for both databases to ensure consistent behavior across all DML operations.
+            // MySQL does not support RETURNING (Supports.Returning is false) and falls back to the base
+            // DELETE + SELECT ROW_COUNT() path. MariaDB 10.5+ supports DELETE RETURNING, used here for the
+            // concurrency-check row count.
             if (_options.ServerVersion.Supports.Returning)
             {
                 AppendReturningClause(commandStringBuilder, [], "1");

--- a/test/EFCore.MySql.FunctionalTests/Update/NonSharedModelUpdatesMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Update/NonSharedModelUpdatesMySqlTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
@@ -5,6 +6,8 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.Update;
 using Microting.EntityFrameworkCore.MySql.FunctionalTests.TestUtilities;
 using Microting.EntityFrameworkCore.MySql.Tests;
+using Microting.EntityFrameworkCore.MySql.Tests.TestUtilities.Attributes;
+using Xunit;
 
 namespace Microting.EntityFrameworkCore.MySql.FunctionalTests.Update;
 
@@ -168,6 +171,63 @@ WHERE `Id` = @p5;
 SELECT ROW_COUNT();
 """);
         }
+    }
+
+    // Regression test for https://github.com/microting/Pomelo.EntityFrameworkCore.MySql/issues/353
+    // A database-generated value (here a timestamp) that is part of a composite primary key must be read
+    // back after INSERT. The only mechanism that can do that on MySQL/MariaDB is INSERT ... RETURNING;
+    // the LAST_INSERT_ID() fallback only works for AUTO_INCREMENT integer keys, so it matched 0 rows and
+    // threw DbUpdateConcurrencyException. RETURNING requires MariaDB 10.5+ (MySQL has no RETURNING at all).
+    [ConditionalFact]
+    [SupportedServerVersionCondition("Returning")]
+    public async Task Insert_reads_back_database_generated_key_in_composite_key()
+    {
+        var contextFactory = await InitializeAsync<DownloadContext>();
+        await using var context = contextFactory.CreateContext();
+
+        var download = new Download { UserId = 1, Version = 1 };
+        context.Add(download);
+
+        // Scope the SQL assertions below to the INSERT only (exclude schema-creation SQL).
+        TestSqlLoggerFactory.Clear();
+
+        // Must not throw DbUpdateConcurrencyException (the symptom of issue #353).
+        await context.SaveChangesAsync();
+
+        // The generated timestamp must have been propagated back into the tracked entity.
+        Assert.NotEqual(default(DateTime), download.DateTime);
+
+        // It must have been read back via RETURNING, not the LAST_INSERT_ID() fallback.
+        Assert.Contains("RETURNING", TestSqlLoggerFactory.Sql);
+        Assert.DoesNotContain("LAST_INSERT_ID", TestSqlLoggerFactory.Sql);
+
+        // And it must round-trip from the database.
+        context.ChangeTracker.Clear();
+        var reloaded = await context.Set<Download>().SingleAsync();
+        Assert.Equal(download.UserId, reloaded.UserId);
+        Assert.Equal(download.Version, reloaded.Version);
+        Assert.Equal(download.DateTime, reloaded.DateTime);
+    }
+
+    private class DownloadContext(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Download>(
+                b =>
+                {
+                    b.HasKey(e => new { e.UserId, e.Version, e.DateTime });
+                    b.Property(e => e.DateTime)
+                        .HasColumnType("timestamp(6)")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP(6)")
+                        .ValueGeneratedOnAdd();
+                });
+    }
+
+    private class Download
+    {
+        public int UserId { get; set; }
+        public int Version { get; set; }
+        public DateTime DateTime { get; set; }
     }
 
     private void AssertSql(params string[] expected)


### PR DESCRIPTION
Closes #353.

A database-generated value that is part of a composite primary key (e.g. a
generated `timestamp(6)`) could not be read back after INSERT on MariaDB. The
provider fell back to `SELECT ... WHERE <key> = LAST_INSERT_ID()`, which only
works for `AUTO_INCREMENT` integer keys, so it matched 0 rows and threw
`DbUpdateConcurrencyException`. The correct mechanism on MariaDB is
`INSERT ... RETURNING`, which is what Pomelo 9.x / upstream used.

### Root cause
A previous change hard-coded `MariaDbServerVersion.Returning` to `false` and added
an `AppendUpdateOperation` override that emitted `UPDATE ... RETURNING` (invalid on
MariaDB). Disabling RETURNING masked the bad UPDATE path but also disabled the
working INSERT/DELETE RETURNING path that database-generated key columns depend on.

### Fix (restores the original Pomelo behavior)
- `MariaDbServerVersion.Returning => ServerVersion.Version >= new Version(10, 5, 0)`
  again (MySQL still has no RETURNING).
- Remove the `AppendUpdateOperation` / `AppendUpdateReturningOperation` overrides so
  UPDATE uses the base `UpdateAndSelectSqlGenerator` (UPDATE + SELECT) path — MariaDB
  has no `UPDATE ... RETURNING`. INSERT/DELETE RETURNING are unchanged and simply work
  again once the capability flag is restored.
- Add a regression test for a DB-generated timestamp in a composite key.

### Behavior change
On MariaDB ≥ 10.5, INSERT/DELETE commands that read back store-generated values again
use a `RETURNING` clause; UPDATE continues to use UPDATE + `SELECT ... WHERE ROW_COUNT() = 1`
on every server. MySQL is unaffected.

### Testing
- New test `NonSharedModelUpdatesMySqlTest.Insert_reads_back_database_generated_key_in_composite_key`
  reproduces #353 and passes on **real MariaDB 11.6.2** (the version from the issue);
  the full functional suite (29k+ tests) is green on that leg.
- `MySqlUpdateSqlGeneratorTest` and `MySqlMigrationsSqlGeneratorTest` confirm INSERT/DELETE
  emit `RETURNING` and UPDATE stays SELECT-based.
- The only red legs in CI are pre-existing flaky query tests (e.g. `EntitySplittingQueryMySqlTest`,
  `Throws_on_concurrent_query_first`) that are also red on `master` and unrelated to this change.