### PR TITLE
fix: restore old string translation from pomelo 8.0

### DIFF
--- a/src/EFCore.MySql/Query/Internal/MySqlObjectToStringTranslator.cs
+++ b/src/EFCore.MySql/Query/Internal/MySqlObjectToStringTranslator.cs
@@ -91,9 +91,7 @@ namespace Microting.EntityFrameworkCore.MySql.Query.Internal
 
             // Enums are handled by EnumMethodTranslator.
             return _supportedTypes.Contains(instance.Type)
-                ? _sqlExpressionFactory.Coalesce(
-                    _sqlExpressionFactory.Convert(instance, typeof(string)),
-                    _sqlExpressionFactory.Constant(string.Empty))
+                ? _sqlExpressionFactory.Convert(instance, typeof(string))
                 : null;
         }
     }


### PR DESCRIPTION
Restores previous tostring query translation from older Pomelo versions. See #360