### PR TITLE
Fix regression to allow LIKE translation for string comparison queries with non-constant args

### DIFF
--- a/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
+++ b/src/EFCore.MySql/Query/ExpressionTranslators/Internal/MySqlStringComparisonMethodTranslator.cs
@@ -524,8 +524,7 @@ namespace Microting.EntityFrameworkCore.MySql.Query.ExpressionTranslators.Intern
             RelationalTypeMapping stringTypeMapping,
             StartsEndsWithContains methodType)
         {
-            if (pattern is SqlParameterExpression patternParameter &&
-                patternParameter.Name.StartsWith("@", StringComparison.Ordinal))
+            if (pattern is SqlParameterExpression patternParameter)
             {
                 // The pattern is a parameter, register a runtime parameter that will contain the rewritten LIKE pattern, where
                 // all special characters have been escaped.

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindMiscellaneousQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindMiscellaneousQueryMySqlTest.cs
@@ -4161,12 +4161,12 @@ FROM `Customers` AS `c`
 
         AssertSql(
             """
-@NewLine='
-' (Size = 5) (DbType = StringFixedLength)
+@NewLine_contains='%
+%' (Size = 5) (DbType = StringFixedLength)
 
 SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
-WHERE (LOCATE(@NewLine, `c`.`CustomerID`) > 0) OR (@NewLine LIKE '')
+WHERE `c`.`CustomerID` LIKE @NewLine_contains
 """);
     }
 
@@ -5674,11 +5674,11 @@ FROM (
 
         AssertSql(
             """
-@prefix='A' (Size = 5) (DbType = StringFixedLength)
+@prefix_startswith='A%' (Size = 5) (DbType = StringFixedLength)
 
 SELECT `c`.`CustomerID`
 FROM `Customers` AS `c`
-WHERE LEFT(`c`.`CustomerID`, CHAR_LENGTH(@prefix)) = @prefix
+WHERE `c`.`CustomerID` LIKE @prefix_startswith
 """);
     }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindQueryFiltersQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindQueryFiltersQueryMySqlTest.cs
@@ -22,11 +22,11 @@ namespace Microting.EntityFrameworkCore.MySql.FunctionalTests.Query
 
         AssertSql(
 """
-@ef_filter__TenantPrefix='B' (Size = 40)
+@ef_filter__TenantPrefix_startswith='B%' (Size = 40)
 
 SELECT COUNT(*)
 FROM `Customers` AS `c`
-WHERE LEFT(`c`.`CompanyName`, CHAR_LENGTH(@ef_filter__TenantPrefix)) = @ef_filter__TenantPrefix
+WHERE `c`.`CompanyName` LIKE @ef_filter__TenantPrefix_startswith
 """);
         }
 

--- a/test/EFCore.MySql.FunctionalTests/Query/NorthwindStringComparisonFunctionsQueryMySqlTest.cs
+++ b/test/EFCore.MySql.FunctionalTests/Query/NorthwindStringComparisonFunctionsQueryMySqlTest.cs
@@ -376,6 +376,24 @@ WHERE LCASE(`c`.`CustomerID`) LIKE CONVERT(LCASE('%nto%') USING utf8mb4) COLLATE
         }
 
         [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task StringContains_parameter(bool async)
+        {
+            var pattern = "anto";
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.CustomerID.Contains(pattern)),
+                assertEmpty: true);
+
+            var sql = Fixture.TestSqlLoggerFactory.Sql;
+
+            // When a non-constant parameter is used, the query should still use a LIKE operator in the translation
+            // and not fall back to using a LOCATE function.
+            Assert.Contains("LIKE", sql);
+            Assert.DoesNotContain("LOCATE", sql);
+        }
+
+        [ConditionalTheory]
         [InlineData(StringComparison.OrdinalIgnoreCase, 1, false)]
         [InlineData(StringComparison.OrdinalIgnoreCase, 1, true)]
         [InlineData(StringComparison.CurrentCultureIgnoreCase, 1, false)]
@@ -496,6 +514,24 @@ WHERE LCASE(LCASE(`c`.`CustomerID`)) LIKE CONVERT(LCASE('anto%') USING utf8mb4) 
         }
 
         [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task StringStartsWith_parameter(bool async)
+        {
+            var pattern = "anto";
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.CustomerID.StartsWith(pattern)),
+                assertEmpty: true);
+
+            var sql = Fixture.TestSqlLoggerFactory.Sql;
+
+            // When a non-constant parameter is used, the query should still use a LIKE operator in the translation
+            // and not fall back to using a LEFT function.
+            Assert.Contains("LIKE", sql);
+            Assert.DoesNotContain("LEFT", sql);
+        }
+
+        [ConditionalTheory]
         [InlineData(StringComparison.OrdinalIgnoreCase, 1, false)]
         [InlineData(StringComparison.OrdinalIgnoreCase, 1, true)]
         [InlineData(StringComparison.CurrentCultureIgnoreCase, 1, false)]
@@ -611,6 +647,24 @@ WHERE LCASE(`c`.`CustomerID`) LIKE CONVERT(LCASE('%nton') USING utf8mb4) COLLATE
                 @"SELECT `c`.`CustomerID`, `c`.`Address`, `c`.`City`, `c`.`CompanyName`, `c`.`ContactName`, `c`.`ContactTitle`, `c`.`Country`, `c`.`Fax`, `c`.`Phone`, `c`.`PostalCode`, `c`.`Region`
 FROM `Customers` AS `c`
 WHERE LCASE(`c`.`CustomerID`) LIKE CONVERT(LCASE('%nton') USING utf8mb4) COLLATE utf8mb4_bin");
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public async Task StringEndsWith_parameter(bool async)
+        {
+            var pattern = "anto";
+            await AssertQuery(
+                async,
+                ss => ss.Set<Customer>().Where(c => c.CustomerID.EndsWith(pattern)),
+                assertEmpty: true);
+
+            var sql = Fixture.TestSqlLoggerFactory.Sql;
+
+            // When a non-constant parameter is used, the query should still use a LIKE operator in the translation
+            // and not fall back to using a RIGHT function.
+            Assert.Contains("LIKE", sql);
+            Assert.DoesNotContain("RIGHT", sql);
         }
 
         [ConditionalTheory]


### PR DESCRIPTION
Closes #386

Resolves regression introduced during the upgrade to .NET 10 (https://github.com/microting/Pomelo.EntityFrameworkCore.MySql/commit/4ac27f6c428356432817e8fbd86ee005f284ad00)

In EF Core 9, the `.Name` property on `SqlParameterExpression` was prefixed with "__", i.e. `QueryCompilationContext.QueryParameterPrefix`. In EF Core 10, the prefix was removed as they were no longer needed to distinguish between parameter types (dedicated types were introduced). The prefix was not replaced with "@" or any other symbol, thus the existing guard in `GetLikeExpressionUsingParameter` will always fail. Similar guard statements were removed in EF Core 10 for the first party Sql server and Sqlite EFCore implementations.

Removing the guard allows the translator to use LIKE expressions for StartsWith, EndsWith, and Contains methods with non-constant arguments. For example, the following query (excerpt from repro code in issue):

```csharp
await context.Widgets.Where(x => x.Name.StartsWith(pattern)).FirstOrDefaultAsync();
```

will translate to the following SQL with the changes from this PR:

```sql
SELECT `w`.`Id`, `w`.`Name`
FROM `Widgets` AS `w`
WHERE `w`.`Name` LIKE @pattern_startswith
LIMIT 1
```